### PR TITLE
Release candidate 1

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -260,6 +260,12 @@ stages:
             pool:
               vmImage: ubuntu-latest
             steps:
+            # Install the nuget tool.
+            - task: NuGetToolInstaller@0
+              displayName: 'Use NuGet >=5.2.0'
+              inputs:
+                versionSpec: '>=5.2.0'
+                checkLatest: true
             - task: DownloadPipelineArtifact@2
               displayName: Download nupkg from artifacts
               inputs:

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -75,7 +75,7 @@ stages:
         inputs:
           command: test
           projects: '$(Build.SourcesDirectory)\Microsoft.Kiota.Serialization.Form.sln'
-          arguments: '--configuration $(BuildConfiguration) --no-build'
+          arguments: '--configuration $(BuildConfiguration) --no-build -f net6.0'
 
       # CredScan
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-rc.1] - 2022-12-15
+
+### Changed
+
+- Release candidate 1
+
 ## [1.0.0-preview.1] - 2022-12-15
 
 ### Added

--- a/src/Microsoft.Kiota.Serialization.Form.csproj
+++ b/src/Microsoft.Kiota.Serialization.Form.csproj
@@ -16,7 +16,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>rc.1</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -25,15 +25,16 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-        - Initial package release.
+        - Release candidate 1
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.19" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.1" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
@@ -42,6 +43,10 @@
 
   <ItemGroup>
     <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>

--- a/tests/Microsoft.Kiota.Serialization.Form.Tests.csproj
+++ b/tests/Microsoft.Kiota.Serialization.Form.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Microsoft.Kiota.Serialization.Form.Tests.csproj
+++ b/tests/Microsoft.Kiota.Serialization.Form.Tests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
This PR creates a release candidate release for the library

Changes include -
- Ensure the nuget push task uses version greater than 5.2.0 to ensure debug symbols are pushed
- Include readme in nuget package in accordance with https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/
- Adds `net462` target to the test project so that project is tested against NetFramework as well.