### PR TITLE
Switch to windows runner for build and test GH action

### DIFF
--- a/.github/workflows/build-and_test.yml
+++ b/.github/workflows/build-and_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     env:
       solutionName: Microsoft.Kiota.Serialization.Form.sln
     steps:


### PR DESCRIPTION
This PR switches to windows runner for build and test GH action as net framework tests are randomly crashing on linux runners.