### PR TITLE
Move Cast<T> call when in .NET Standard.

### DIFF
--- a/src/FormSerializationWriter.cs
+++ b/src/FormSerializationWriter.cs
@@ -225,11 +225,11 @@ public class FormSerializationWriter : ISerializationWriter
                         Enum.GetValues<T>()
 #else
                         Enum.GetValues(typeof(T))
+                            .Cast<T>()
 #endif
-                                        .Cast<T>()
-                                        .Where(x => value.Value.HasFlag(x))
-                                        .Select(static x => Enum.GetName(typeof(T),x))
-                                        .Select(static x => x.ToFirstCharacterLowerCase())));
+                            .Where(x => value.Value.HasFlag(x))
+                            .Select(static x => Enum.GetName(typeof(T),x))
+                            .Select(static x => x.ToFirstCharacterLowerCase())));
             else WriteStringValue(key, value.Value.ToString().ToFirstCharacterLowerCase());
         }
     }


### PR DESCRIPTION
Same concern addressed in https://github.com/microsoft/kiota-serialization-json-dotnet/pull/174/commits/76f5aded5c15b828e7ff0a6f39aa052115a4e054, as discussed here: https://github.com/microsoft/kiota-serialization-json-dotnet/pull/174#discussion_r1472518527. And a follow up to https://github.com/microsoft/kiota-serialization-form-dotnet/pull/107