### PR TITLE
Fix IsTrimmable property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.1.3] - 2024-02-05
+
+### Changed
+
+- Fixes `IsTrimmable` property on the project.
+
 ## [1.1.2] - 2024-01-30
 
 ### Changed

--- a/src/Microsoft.Kiota.Serialization.Form.csproj
+++ b/src/Microsoft.Kiota.Serialization.Form.csproj
@@ -16,7 +16,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.1.2</VersionPrefix>
+    <VersionPrefix>1.1.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Microsoft.Kiota.Serialization.Form.csproj
+++ b/src/Microsoft.Kiota.Serialization.Form.csproj
@@ -36,7 +36,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>$(NoWarn);NU5048;NETSDK1138</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == 'net5.0'">    
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">    
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/tests/FormParseNodeFactoryTests.cs
+++ b/tests/FormParseNodeFactoryTests.cs
@@ -10,7 +10,7 @@ public class FormParseNodeFactoryTests
     public void GetsWriterForFormContentType()
     {
         using var formStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
-        var formParseNode = _formParseNodeFactory.GetRootParseNode(_formParseNodeFactory.ValidContentType,formStream);
+        var formParseNode = _formParseNodeFactory.GetRootParseNode(_formParseNodeFactory.ValidContentType, formStream);
 
         // Assert
         Assert.NotNull(formParseNode);
@@ -21,7 +21,7 @@ public class FormParseNodeFactoryTests
     {
         var streamContentType = "application/octet-stream";
         using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => _formParseNodeFactory.GetRootParseNode(streamContentType,jsonStream));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => _formParseNodeFactory.GetRootParseNode(streamContentType, jsonStream));
 
         // Assert
         Assert.NotNull(exception);
@@ -31,10 +31,10 @@ public class FormParseNodeFactoryTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void ThrowsArgumentNullExceptionForNoContentType(string contentType)
+    public void ThrowsArgumentNullExceptionForNoContentType(string? contentType)
     {
         using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
-        var exception = Assert.Throws<ArgumentNullException>(() => _formParseNodeFactory.GetRootParseNode(contentType,jsonStream));
+        var exception = Assert.Throws<ArgumentNullException>(() => _formParseNodeFactory.GetRootParseNode(contentType!, jsonStream));
 
         // Assert
         Assert.NotNull(exception);

--- a/tests/FormSerializationWriterFactoryTests.cs
+++ b/tests/FormSerializationWriterFactoryTests.cs
@@ -7,7 +7,7 @@ public class FormSerializationWriterFactoryTests
     public void GetsWriterForFormContentType()
     {
         var formWriter = _formSerializationFactory.GetSerializationWriter(_formSerializationFactory.ValidContentType);
-        
+
         // Assert
         Assert.NotNull(formWriter);
         Assert.IsAssignableFrom<FormSerializationWriter>(formWriter);
@@ -27,9 +27,9 @@ public class FormSerializationWriterFactoryTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void ThrowsArgumentNullExceptionForNoContentType(string contentType)
+    public void ThrowsArgumentNullExceptionForNoContentType(string? contentType)
     {
-        var exception = Assert.Throws<ArgumentNullException>(() => _formSerializationFactory.GetSerializationWriter(contentType));
+        var exception = Assert.Throws<ArgumentNullException>(() => _formSerializationFactory.GetSerializationWriter(contentType!));
 
         // Assert
         Assert.NotNull(exception);


### PR DESCRIPTION
This PR fixes the condition gating the `IsTrimmable` property in the .csproj, and any new build errors that this causes.

This is related to: https://github.com/microsoft/kiota-abstractions-dotnet/issues/188

Also fixes some unrelated test warnings.