### PR TITLE
Update DynamicallyAccessMembers for IParseNode Enum methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# JetBrains Idea based IDEs
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.1.5] - 2024-02-27
+
+### Changed
+
+- Reduced `DynamicallyAccessedMembers` scope for enum methods to prevent ILC warnings.
+
 ## [1.1.4] - 2024-02-26
 
 ### Changed

--- a/src/FormParseNode.cs
+++ b/src/FormParseNode.cs
@@ -187,7 +187,7 @@ public class FormParseNode : IParseNode
     /// <inheritdoc/>
     public Time? GetTimeValue() => DateTime.TryParse(DecodedValue, out var result) ? new Time(result) : null;
 #if NET5_0_OR_GREATER
-    IEnumerable<T?> IParseNode.GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>()
+    IEnumerable<T?> IParseNode.GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>()
 #else
     IEnumerable<T?> IParseNode.GetCollectionOfEnumValues<T>()
 #endif
@@ -195,18 +195,15 @@ public class FormParseNode : IParseNode
         return DecodedValue.Split(new char[] {','}, StringSplitOptions.RemoveEmptyEntries).Select(v => GetEnumValueInternal<T>(v));
     }
 #if NET5_0_OR_GREATER
-    T? IParseNode.GetEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>()
+    T? IParseNode.GetEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>()
 #else
     T? IParseNode.GetEnumValue<T>()
 #endif
     {
         return GetEnumValueInternal<T>(DecodedValue);
     }
-#if NET5_0_OR_GREATER
-    private static T? GetEnumValueInternal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>(string value) where T : struct, Enum
-#else
+    
     private static T? GetEnumValueInternal<T>(string value) where T : struct, Enum
-#endif
     {
         if(string.IsNullOrEmpty(value))
             return null;

--- a/src/Microsoft.Kiota.Serialization.Form.csproj
+++ b/src/Microsoft.Kiota.Serialization.Form.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.10" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.11" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Microsoft.Kiota.Serialization.Form.csproj
+++ b/src/Microsoft.Kiota.Serialization.Form.csproj
@@ -16,7 +16,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Updates DynamicallyAccessMembers for IParseNode Enum methods to align with changes from https://github.com/microsoft/kiota-abstractions-dotnet/pull/202

This will need https://github.com/microsoft/kiota-abstractions-dotnet/pull/202 to be merged and released, and the new release referenced before it will successfully build.