### PR TITLE
Remove LINQ usage from Enum conversion from/to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.0] - 2024-05-13
 
+### Changed
+
+- Updated serialization and deserialization of enums to remove LINQ to resolve NativeAOT compatibility issue
+
 ### Added
 
 - Implements IAsyncParseNodeFactory interface which adds async support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.0] - 2024-05-13
+## [1.2.1] - 2024-05-20
 
 ### Changed
 
 - Updated serialization and deserialization of enums to remove LINQ to resolve NativeAOT compatibility issue
+
+## [1.2.0] - 2024-05-13
 
 ### Added
 

--- a/src/FormSerializationWriter.cs
+++ b/src/FormSerializationWriter.cs
@@ -220,16 +220,25 @@ public class FormSerializationWriter : ISerializationWriter
         if(value.HasValue)
         {
             if(typeof(T).GetCustomAttributes<FlagsAttribute>().Any())
-                WriteStringValue(key, string.Join(",",
+            {
+                var values =
 #if NET5_0_OR_GREATER
-                        Enum.GetValues<T>()
+                    Enum.GetValues<T>();
 #else
-                        Enum.GetValues(typeof(T))
-                            .Cast<T>()
+                    Enum.GetValues(typeof(T)).Cast<T>();
 #endif
-                            .Where(x => value.Value.HasFlag(x))
-                            .Select(static x => Enum.GetName(typeof(T),x))
-                            .Select(static x => x.ToFirstCharacterLowerCase())));
+                StringBuilder valueNames = new StringBuilder();
+                foreach(var x in values)
+                {
+                    if(value.Value.HasFlag(x) && Enum.GetName(typeof(T), x) is string valueName)
+                    {
+                        if(valueNames.Length > 0)
+                            valueNames.Append(",");
+                        valueNames.Append(valueName.ToFirstCharacterLowerCase());
+                    }
+                }
+                WriteStringValue(key, valueNames.ToString());
+            }
             else WriteStringValue(key, value.Value.ToString().ToFirstCharacterLowerCase());
         }
     }

--- a/src/Microsoft.Kiota.Serialization.Form.csproj
+++ b/src/Microsoft.Kiota.Serialization.Form.csproj
@@ -16,7 +16,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This prevents unintended and unbound generic specialization expansion in the NativeAOT compiler.

Fixes #142 